### PR TITLE
Reset time functionality added for state saving/restoring processes (NGWPC 9622)

### DIFF
--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -620,8 +620,8 @@ contains
     character (len=*), intent(in) :: name
     character (len=*), intent(out) :: type
     integer :: bmi_status
-    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "uint64" !pads spaces upto 2048.
-    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "uint64" !pads spaces upto 2048
+    character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
+    character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_state = "character" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
@@ -875,6 +875,12 @@ contains
     case("XXAJ")
       size = sizeof(parameters%XXAJ)        ! 'sizeof' in gcc & ifort
       bmi_status = BMI_SUCCESS
+    case("serialization_create", "serialization_size", "serialization_free")
+      size = storage_size(0_int32)/8
+      bmi_status = BMI_SUCCESS
+    case("serialization_state")
+      size = 1
+      bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -892,7 +898,7 @@ contains
     integer :: s1, s2, s3, grid, grid_size, item_size
 
     if (name == "serialization_create" .or. name == "serialization_size") then
-      nbytes = storage_size(0_int64)/8 !returns size in bits. So, divide by 8 for bytes.
+      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
       bmi_status = BMI_SUCCESS
     else if (name == "serialization_state") then
       if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
@@ -959,7 +965,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
         else
-            dest = size(this%model%serialization_buffer,KIND=int64)
+            dest = size(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
     case default

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -1306,6 +1306,15 @@ contains
             deallocate(this%model%serialization_buffer)
          end if
          bmi_status = BMI_SUCCESS
+      case("reset_time")
+         call reset_model_time(this%model, exec_status)
+         if (exec_status == 0) then
+            bmi_status = BMI_SUCCESS
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_INFO)
+         else
+            bmi_status = BMI_FAILURE
+            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+         end if
       case default
        bmi_status = BMI_FAILURE
        call write_log("bmi:noahowp_set_int: invalid var " // name, LOG_LEVEL_WARNING)

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -650,6 +650,9 @@ contains
     case ('serialization_free')
        type = ser_free
        bmi_status = BMI_SUCCESS
+    case ("reset_time")
+       type = "double"
+       bmi_status = BMI_SUCCESS
     case default
        type = "-"
        bmi_status = BMI_FAILURE
@@ -881,6 +884,8 @@ contains
     case("serialization_state")
       size = 1
       bmi_status = BMI_SUCCESS
+    case("reset_time")
+      bmi_status = noahowp_var_nbytes(this, name, size)
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -896,15 +901,24 @@ contains
     integer, intent(out) :: nbytes
     integer :: bmi_status
     integer :: s1, s2, s3, grid, grid_size, item_size
+    double precision :: r
 
-    if (name == "serialization_create" .or. name == "serialization_size") then
+    if (name == "reset_time") then
+      nbytes = storage_size(r) / 8
+      bmi_status = BMI_SUCCESS
+    else if (name == "serialization_create" .or. name == "serialization_size") then
       nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
       bmi_status = BMI_SUCCESS
     else if (name == "serialization_state") then
       if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-         nbytes = -1
-         call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-         bmi_status = BMI_FAILURE
+        if (this%model%serialization_size > 0) then
+          nbytes = this%model%serialization_size
+          bmi_status = BMI_SUCCESS
+        else
+          nbytes = -1
+          call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+          bmi_status = BMI_FAILURE
+        end if
       else
          nbytes = size(this%model%serialization_buffer,KIND=int64)
          bmi_status = BMI_SUCCESS
@@ -1300,6 +1314,12 @@ contains
 !     case("model__identification_number")
 !        this%model%id = src(1)
 !        bmi_status = BMI_SUCCESS
+      case("serialization_size")
+        !hacky way of letting the BMI set the serialized data
+        !The C to Fortran interface takes a C pointer to the data, then gets the size of the data array by querying the value behind the scenes.
+        !This behavior makes it necessary to lie to the BMI implementation about how large the incoming data is expected to be.
+        this%model%serialization_size = src(1)
+        bmi_status = BMI_SUCCESS
       case("serialization_create")
          call new_serialization_request(this%model, exec_status)
          if (exec_status == 0) then
@@ -1309,23 +1329,17 @@ contains
             bmi_status = BMI_FAILURE
             call write_log(" Failed to create serialized data for state saving", LOG_LEVEL_FATAL) 
          end if
+         this%model%serialization_size = -1
       case("serialization_state")
          call deserialize_mp_buffer(this%model,src)
+         this%model%serialization_size = -1
          bmi_status = BMI_SUCCESS
       case("serialization_free")
          if(allocated(this%model%serialization_buffer)) then
             deallocate(this%model%serialization_buffer)
          end if
+         this%model%serialization_size = -1
          bmi_status = BMI_SUCCESS
-      case("reset_time")
-         call reset_model_time(this%model, exec_status)
-         if (exec_status == 0) then
-            bmi_status = BMI_SUCCESS
-            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
-         else
-            bmi_status = BMI_FAILURE
-            call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
-         end if
       case default
        bmi_status = BMI_FAILURE
        call write_log("bmi:noahowp_set_int: invalid var " // name, LOG_LEVEL_WARNING)
@@ -1465,10 +1479,20 @@ contains
     character (len=*), intent(in) :: name
     double precision, intent(in) :: src(:)
     integer :: bmi_status
+    integer(kind=int64) :: exec_status
 
     !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR DOUBLE VARS =================
 
     select case(name)
+    case("reset_time")
+      call reset_model_time(this%model, exec_status)
+      if (exec_status == 0) then
+        bmi_status = BMI_SUCCESS
+        call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
+      else
+        bmi_status = BMI_FAILURE
+        call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 
+      end if
     case default
        bmi_status = BMI_FAILURE
        call write_log("bmi:noahowp_set_double: invalid var " // name, LOG_LEVEL_WARNING)

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -724,6 +724,7 @@ contains
     character (len=*), intent(in) :: name
     integer, intent(out) :: size
     integer :: bmi_status
+    double precision :: d
 
     associate(forcing    => this%model%forcing,   &
               water      => this%model%water,     &
@@ -878,14 +879,12 @@ contains
     case("XXAJ")
       size = sizeof(parameters%XXAJ)        ! 'sizeof' in gcc & ifort
       bmi_status = BMI_SUCCESS
-    case("serialization_create", "serialization_size", "serialization_free")
-      size = storage_size(0_int32)/8
-      bmi_status = BMI_SUCCESS
-    case("serialization_state")
-      size = 1
+    case("serialization_create", "serialization_size", "serialization_free", "serialization_state")
+      size = sizeof(this%model%serialization_size)
       bmi_status = BMI_SUCCESS
     case("reset_time")
-      bmi_status = noahowp_var_nbytes(this, name, size)
+      size = sizeof(d)
+      bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE
@@ -901,31 +900,21 @@ contains
     integer, intent(out) :: nbytes
     integer :: bmi_status
     integer :: s1, s2, s3, grid, grid_size, item_size
-    double precision :: r
 
-    if (name == "reset_time") then
-      nbytes = storage_size(r) / 8
-      bmi_status = BMI_SUCCESS
-    else if (name == "serialization_create" .or. name == "serialization_size") then
-      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
-      bmi_status = BMI_SUCCESS
+    if (name == "reset_time" .or. name == "serialization_create" .or. name == "serialization_size" .or. name == "serialization_free") then
+      bmi_status = noahowp_var_itemsize(this, name, nbytes)
     else if (name == "serialization_state") then
-      if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-        if (this%model%serialization_size > 0) then
-          nbytes = this%model%serialization_size
-          bmi_status = BMI_SUCCESS
-        else
-          nbytes = -1
-          call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-          bmi_status = BMI_FAILURE
-        end if
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+        nbytes = sizeof(this%model%serialization_buffer)
+        bmi_status = BMI_SUCCESS
+      else if (this%model%serialization_size > 0) then
+        nbytes = this%model%serialization_size
+        bmi_status = BMI_SUCCESS
       else
-         nbytes = size(this%model%serialization_buffer,KIND=int64)
-         bmi_status = BMI_SUCCESS
+        nbytes = -1
+        call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+        bmi_status = BMI_FAILURE
       end if
-    else if (name == "serialization_free") then 
-      nbytes = storage_size(0_int32)/8 !returns size in bits. So, divide by 8 for bytes.
-      bmi_status = BMI_SUCCESS
     else
       s1 = this%get_var_grid(name, grid)
       s2 = this%get_grid_size(grid, grid_size)
@@ -979,7 +968,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
         else
-            dest = size(this%model%serialization_buffer)
+            dest = sizeof(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
     case("serialization_state")
@@ -987,7 +976,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
         else
-            dest = transfer(this%model%serialization_buffer, dest)
+            dest(:) = this%model%serialization_buffer(:)
             bmi_status = BMI_SUCCESS
          end if
     case default

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -1304,7 +1304,7 @@ contains
          call new_serialization_request(this%model, exec_status)
          if (exec_status == 0) then
             bmi_status = BMI_SUCCESS
-            call write_log("Serialization for state saving complete", LOG_LEVEL_INFO)
+            call write_log("Serialization for state saving complete", LOG_LEVEL_DEBUG)
          else
             bmi_status = BMI_FAILURE
             call write_log(" Failed to create serialized data for state saving", LOG_LEVEL_FATAL) 
@@ -1321,7 +1321,7 @@ contains
          call reset_model_time(this%model, exec_status)
          if (exec_status == 0) then
             bmi_status = BMI_SUCCESS
-            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_INFO)
+            call write_log("Time variables reset successfully for state restoring", LOG_LEVEL_DEBUG)
          else
             bmi_status = BMI_FAILURE
             call write_log(" Failed to reset time variables for state restoring", LOG_LEVEL_FATAL) 

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -967,7 +967,7 @@ contains
       bmi_status = BMI_SUCCESS
     case("serialization_size")
       if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
-        dest(:) = size(this%model%serialization_buffer)
+        dest(:) = sizeof(this%model%serialization_buffer)
         bmi_status = BMI_SUCCESS
       else
         call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -968,7 +968,7 @@ contains
             call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
             bmi_status = BMI_FAILURE
         else
-            dest = sizeof(this%model%serialization_buffer)
+            dest = size(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
     case("serialization_state")

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -954,6 +954,8 @@ contains
     character (len=*), intent(in) :: name
     integer, intent(inout) :: dest(:)
     integer :: bmi_status
+    character(len=20) :: dest_size
+    character(len=20) :: ser_size
 
     select case(name)
 !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR INTEGER VARS =================
@@ -961,24 +963,33 @@ contains
 !        dest = [this%model%id]
 !        bmi_status = BMI_SUCCESS
     case("ISNOW")
-       dest(:) = this%model%water%ISNOW
-       bmi_status = BMI_SUCCESS
+      dest(:) = this%model%water%ISNOW
+      bmi_status = BMI_SUCCESS
     case("serialization_size")
-        if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-            bmi_status = BMI_FAILURE
-        else
-            dest = size(this%model%serialization_buffer)
-            bmi_status = BMI_SUCCESS
-         end if
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+        dest(:) = size(this%model%serialization_buffer)
+        bmi_status = BMI_SUCCESS
+      else
+        call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+        bmi_status = BMI_FAILURE
+      end if
     case("serialization_state")
-        if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
-            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
-            bmi_status = BMI_FAILURE
+      if(allocated(this%model%serialization_buffer) .and. size(this%model%serialization_buffer) > 0) then
+        if(size(dest) == size(this%model%serialization_buffer)) then
+          dest(:) = this%model%serialization_buffer(:)
+          bmi_status = BMI_SUCCESS
         else
-            dest(:) = this%model%serialization_buffer(:)
-            bmi_status = BMI_SUCCESS
-         end if
+          write(dest_size, "(I20)") size(dest)
+          write(ser_size, "(I20)") size(this%model%serialization_buffer)
+          call write_log("The destination size (" // trim(dest_size) &
+            // ") does not match the serializations size (" // trim(ser_size) // ")", &
+            LOG_LEVEL_SEVERE)
+          bmi_status = BMI_FAILURE
+        end if
+      else
+        call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+        bmi_status = BMI_FAILURE
+      end if
     case default
        dest(:) = -1
        bmi_status = BMI_FAILURE

--- a/bmi/bmi_noahowp.f90
+++ b/bmi/bmi_noahowp.f90
@@ -622,7 +622,7 @@ contains
     integer :: bmi_status
     character(len=BMI_MAX_TYPE_NAME) :: ser_create = "int" !pads spaces upto 2048.
     character(len=BMI_MAX_TYPE_NAME) :: ser_size = "int" !pads spaces upto 2048
-    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "character" !pads spaces upto 2048
+    character(len=BMI_MAX_TYPE_NAME) :: ser_state = "int" !pads spaces upto 2048
     character(len=BMI_MAX_TYPE_NAME) :: ser_free = "int" !pads spaces upto 2048
 
     select case(name)
@@ -968,6 +968,14 @@ contains
             dest = size(this%model%serialization_buffer)
             bmi_status = BMI_SUCCESS
          end if
+    case("serialization_state")
+        if(.not.allocated(this%model%serialization_buffer) .or. size(this%model%serialization_buffer) == 0) then
+            call write_log("Serialization not set yet!", LOG_LEVEL_WARNING)
+            bmi_status = BMI_FAILURE
+        else
+            dest = transfer(this%model%serialization_buffer, dest)
+            bmi_status = BMI_SUCCESS
+         end if
     case default
        dest(:) = -1
        bmi_status = BMI_FAILURE
@@ -1172,9 +1180,6 @@ contains
      integer :: n_elements
 
      select case(name)
-      case("serialization_state")
-          dest_ptr = this%model%serialization_buffer
-          bmi_status = BMI_SUCCESS
       case default
           bmi_status = BMI_FAILURE
           call write_log("bmi:noahowp_get_ptr_int: invalid var " // name, LOG_LEVEL_WARNING)

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -382,7 +382,7 @@ contains
     else
         exec_status = 0
         model%serialization_buffer = serialization_buffer
-        call write_log("Serialization using messagepack successful!", LOG_LEVEL_INFO)
+        call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request
 

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -392,7 +392,7 @@ contains
         ser_ints = CEILING(real(ser_size) / sizeof(ser_size))
         allocate(model%serialization_buffer(ser_ints + 1))
         model%serialization_buffer(1) = ser_size
-        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)
+        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:))
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -33,6 +33,7 @@ module RunModule
     type(water_type)      :: water
     type(forcing_type)    :: forcing
     type(energy_type)     :: energy
+    integer               :: serialization_size
     byte, dimension(:), allocatable :: serialization_buffer
   end type noahowp_type
 contains
@@ -58,6 +59,8 @@ contains
       !---------------------------------------------------------------------
       !  initialize
       !---------------------------------------------------------------------
+      model%serialization_size = -1
+
       call namelist%ReadNamelist(config_filename)
 
       call levels%Init
@@ -356,6 +359,8 @@ contains
     type(mp_arr_type) :: mp_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
+    integer :: ser_size
+    byte, dimension(4) :: byte_size
 
     mp = msgpack()
     mp_arr = mp_arr_type(5) !forcing, energy, domain, water, parameters
@@ -381,7 +386,14 @@ contains
         exec_status = 1
     else
         exec_status = 0
-        model%serialization_buffer = serialization_buffer
+        if (allocated(model%serialization_buffer)) then
+          deallocate(model%serialization_buffer)
+        end if
+        ser_size = size(serialization_buffer)
+        allocate(model%serialization_buffer(ser_size + 4))
+        byte_size = TRANSFER(ser_size, byte_size, size=4)
+        model%serialization_buffer(1:4) = byte_size(1:4)
+        model%serialization_buffer(5:) = serialization_buffer
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request
@@ -396,11 +408,13 @@ contains
     class(mp_arr_type), allocatable :: arr
     logical :: error, status
     integer(kind=int64) :: index
-    
+
     mp = msgpack()
     !convert integer(4) to integer(1) for messagepack
-    allocate(serialized_data_1b(size(serialized_data, 1, int64)*4_int64))
-    serialized_data_1b = TRANSFER(serialized_data, serialized_data_1b)
+    !the exact size of the serialized data is stored as the first value. This was needed since padding coming from the size not being divisble by 4 caused an error when deserializing using messagepack
+    allocate(serialized_data_1b(serialized_data(1)))
+    serialized_data_1b = TRANSFER(serialized_data(2:), serialized_data_1b, size=serialized_data(1))
+
     call mp%unpack(serialized_data_1b, mpv)
     if (is_arr(mpv)) then
       call get_arr_ref(mpv, arr_all, status) 

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -341,6 +341,8 @@ contains
     type(noahowp_type), intent(inout) :: model
     exec_status = 1
     ! reset time variables to the beginning
+    domain%nowdate   = domain%startdate ! start the model with nowdate = startdate
+    forcing_timestep = domain%dt        ! integer timestep for some subroutine calls
     domain%itime     = 1                ! initialize the time loop counter at 1
     domain%time_dbl  = 0.d0             ! start model run at t = 0; bmi noahowp_current_time reads this value
     exec_status = 0

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -337,6 +337,15 @@ contains
     end associate ! terminate associate block
   END SUBROUTINE solve_noahowp
 
+  SUBROUTINE reset_model_time(this%model, exec_status)
+    type(noahowp_type), intent(inout) :: model
+    exec_status = 1
+    ! reset time variables to the beginning
+    domain%itime     = 1                ! initialize the time loop counter at 1
+    domain%time_dbl  = 0.d0             ! start model run at t = 0; bmi noahowp_current_time reads this value
+    exec_status = 0
+  END SUBROUTINE reset_model_time
+
   SUBROUTINE new_serialization_request (model, exec_status)
     type(noahowp_type), intent(inout) :: model
     class(msgpack), allocatable :: mp

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -337,7 +337,7 @@ contains
     end associate ! terminate associate block
   END SUBROUTINE solve_noahowp
 
-  SUBROUTINE reset_model_time(this%model, exec_status)
+  SUBROUTINE reset_model_time(model, exec_status)
     type(noahowp_type), intent(inout) :: model
     exec_status = 1
     ! reset time variables to the beginning

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -351,33 +351,28 @@ contains
   SUBROUTINE new_serialization_request (model, exec_status)
     type(noahowp_type), intent(inout) :: model
     class(msgpack), allocatable :: mp
-    class(mp_arr_type), allocatable :: mp_sub_arr
-    class(mp_arr_type), allocatable :: mp_arr
+    class(mp_arr_type), allocatable :: mp_forcing_arr, mp_domain_arr, mp_energy_arr 
+    class(mp_arr_type), allocatable :: mp_water_arr, mp_parameters_arr
+    type(mp_arr_type) :: mp_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
 
     mp = msgpack()
-    mp_arr = mp_arr_type(5) !forcing, domain, energy,water, parameters
+    mp_arr = mp_arr_type(5) !forcing, energy, domain, water, parameters
+    call forcing_serialization(model%forcing, mp_forcing_arr)
+    allocate(mp_arr%values(1)%obj, source = mp_forcing_arr) !forcing
 
-    call forcing_serialization(model%forcing,mp_sub_arr)
-    mp_arr%values(1)%obj = mp_sub_arr !forcing
-    deallocate(mp_sub_arr)
+	  call energy_serialization(model%energy,mp_energy_arr)
+    allocate(mp_arr%values(2)%obj, source = mp_energy_arr) !energy
 
-    call energy_serialization(model%energy,mp_sub_arr)
-    mp_arr%values(2)%obj = mp_sub_arr !energy
-    deallocate(mp_sub_arr)
+    call domain_serialization(model%domain,mp_domain_arr)
+    allocate(mp_arr%values(3)%obj, source = mp_domain_arr) !domain
 
-    call domain_serialization(model%domain,mp_sub_arr)
-    mp_arr%values(3)%obj = mp_sub_arr !domain
-    deallocate(mp_sub_arr)
+    call water_serialization(model%water,mp_water_arr)
+    allocate(mp_arr%values(4)%obj, source = mp_water_arr) !water
 
-    call water_serialization(model%water,mp_sub_arr)
-    mp_arr%values(4)%obj = mp_sub_arr !water
-    deallocate(mp_sub_arr)
-
-    call parameters_serialization(model%parameters,mp_sub_arr)
-    mp_arr%values(5)%obj = mp_sub_arr !parameters
-    deallocate(mp_sub_arr)
+    call parameters_serialization(model%parameters,mp_parameters_arr)
+    allocate(mp_arr%values(5)%obj, source = mp_parameters_arr) !parameters
 
     ! pack the data
     call mp%pack_alloc(mp_arr, serialization_buffer)

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -389,7 +389,7 @@ contains
           deallocate(model%serialization_buffer)
         end if
         ser_size = size(serialization_buffer)
-        ser_ints = ser_size / sizeof(ser_size)
+        ser_ints = CEILING(real(ser_size) / sizeof(ser_size))
         allocate(model%serialization_buffer(ser_ints + 1))
         model%serialization_buffer(1) = ser_size
         model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -34,7 +34,7 @@ module RunModule
     type(forcing_type)    :: forcing
     type(energy_type)     :: energy
     integer               :: serialization_size
-    byte, dimension(:), allocatable :: serialization_buffer
+    integer, dimension(:), allocatable :: serialization_buffer
   end type noahowp_type
 contains
 
@@ -359,8 +359,7 @@ contains
     type(mp_arr_type) :: mp_arr
     byte, dimension(:), allocatable :: serialization_buffer
     integer(kind=int64), intent(out) :: exec_status
-    integer :: ser_size
-    byte, dimension(4) :: byte_size
+    integer :: ser_size, ser_ints
 
     mp = msgpack()
     mp_arr = mp_arr_type(5) !forcing, energy, domain, water, parameters
@@ -390,10 +389,10 @@ contains
           deallocate(model%serialization_buffer)
         end if
         ser_size = size(serialization_buffer)
-        allocate(model%serialization_buffer(ser_size + 4))
-        byte_size = TRANSFER(ser_size, byte_size, size=4)
-        model%serialization_buffer(1:4) = byte_size(1:4)
-        model%serialization_buffer(5:) = serialization_buffer
+        ser_ints = ser_size / sizeof(ser_size)
+        allocate(model%serialization_buffer(ser_ints + 1))
+        model%serialization_buffer(1) = ser_size
+        model%serialization_buffer(2:) = transfer(serialization_buffer, model%serialization_buffer(2:), ser_ints)
         call write_log("Serialization using messagepack successful!", LOG_LEVEL_DEBUG)
     end if
   END SUBROUTINE new_serialization_request

--- a/src/RunModule.f90
+++ b/src/RunModule.f90
@@ -339,12 +339,12 @@ contains
 
   SUBROUTINE reset_model_time(model, exec_status)
     type(noahowp_type), intent(inout) :: model
+    integer(kind=int64), intent(out) :: exec_status
     exec_status = 1
     ! reset time variables to the beginning
-    domain%nowdate   = domain%startdate ! start the model with nowdate = startdate
-    forcing_timestep = domain%dt        ! integer timestep for some subroutine calls
-    domain%itime     = 1                ! initialize the time loop counter at 1
-    domain%time_dbl  = 0.d0             ! start model run at t = 0; bmi noahowp_current_time reads this value
+    model%domain%nowdate   = model%domain%startdate ! start the model with nowdate = startdate
+    model%domain%itime     = 1                ! initialize the time loop counter at 1
+    model%domain%time_dbl  = 0.d0             ! start model run at t = 0; bmi noahowp_current_time reads this value
     exec_status = 0
   END SUBROUTINE reset_model_time
 

--- a/src/StateSerialization.f90
+++ b/src/StateSerialization.f90
@@ -200,29 +200,29 @@ SUBROUTINE energy_serialization (energy, mp_arr)
     mp_arr%values(30)%obj = mp_float_type(energy%RSURF) !RSURF
     mp_arr%values(31)%obj = mp_float_type(energy%RHSUR) !RHSUR
     mp_arr%values(32)%obj = mp_float_type(energy%LATHEAV) !LATHEAV
-    mp_arr%values(34)%obj = mp_float_type(energy%GAMMAV) !GAMMAV
-    mp_arr%values(35)%obj = mp_float_type(energy%LATHEAG) !LATHEAG
-    mp_arr%values(36)%obj = mp_float_type(energy%GAMMAG) !GAMMAG
-    mp_arr%values(37)%obj = mp_float_type(energy%TGB) !TGB
-    mp_arr%values(38)%obj = mp_float_type(energy%CMB) !CMB
-    mp_arr%values(39)%obj = mp_float_type(energy%CHB) !CHB
-    mp_arr%values(40)%obj = mp_float_type(energy%Z0WRF) !Z0WRF
-    mp_arr%values(41)%obj = mp_float_type(energy%RSSUN) !RSSUN
-    mp_arr%values(42)%obj = mp_float_type(energy%T2M) !T2M
-    mp_arr%values(43)%obj = mp_float_type(energy%Q1) !Q1
-    mp_arr%values(44)%obj = mp_float_type(energy%Q2E) !Q2E
-    mp_arr%values(45)%obj = mp_float_type(energy%FGEV) !FGEV
-    mp_arr%values(46)%obj = mp_float_type(energy%TS) !TS
-    mp_arr%values(47)%obj = mp_float_type(energy%TAUY) !TAUY
-    mp_arr%values(48)%obj = mp_float_type(energy%GH) !GH
-    mp_arr%values(59)%obj = mp_float_type(energy%SSOIL) !SSOIL
-    mp_arr%values(50)%obj = mp_float_type(energy%TGV) !TGV
-    mp_arr%values(51)%obj = mp_float_type(energy%FCEV) !FCEV
-    mp_arr%values(52)%obj = mp_float_type(energy%CM) !CM
-    mp_arr%values(53)%obj = mp_float_type(energy%FIRA) !FIRA
-    mp_arr%values(54)%obj = mp_float_type(energy%RSSHA) !RSSHA
-    mp_arr%values(55)%obj = mp_float_type(energy%TG) !TG
-    mp_arr%values(57)%obj = mp_float_type(energy%CH) !CH
+    mp_arr%values(33)%obj = mp_float_type(energy%GAMMAV) !GAMMAV
+    mp_arr%values(34)%obj = mp_float_type(energy%LATHEAG) !LATHEAG
+    mp_arr%values(35)%obj = mp_float_type(energy%GAMMAG) !GAMMAG
+    mp_arr%values(36)%obj = mp_float_type(energy%TGB) !TGB
+    mp_arr%values(37)%obj = mp_float_type(energy%CMB) !CMB
+    mp_arr%values(38)%obj = mp_float_type(energy%CHB) !CHB
+    mp_arr%values(39)%obj = mp_float_type(energy%Z0WRF) !Z0WRF
+    mp_arr%values(40)%obj = mp_float_type(energy%RSSUN) !RSSUN
+    mp_arr%values(41)%obj = mp_float_type(energy%T2M) !T2M
+    mp_arr%values(42)%obj = mp_float_type(energy%Q1) !Q1
+    mp_arr%values(43)%obj = mp_float_type(energy%Q2E) !Q2E
+    mp_arr%values(44)%obj = mp_float_type(energy%FGEV) !FGEV
+    mp_arr%values(45)%obj = mp_float_type(energy%TS) !TS
+    mp_arr%values(46)%obj = mp_float_type(energy%TAUY) !TAUY
+    mp_arr%values(47)%obj = mp_float_type(energy%GH) !GH
+    mp_arr%values(48)%obj = mp_float_type(energy%SSOIL) !SSOIL
+    mp_arr%values(49)%obj = mp_float_type(energy%TGV) !TGV
+    mp_arr%values(50)%obj = mp_float_type(energy%FCEV) !FCEV
+    mp_arr%values(51)%obj = mp_float_type(energy%CM) !CM
+    mp_arr%values(52)%obj = mp_float_type(energy%FIRA) !FIRA
+    mp_arr%values(53)%obj = mp_float_type(energy%RSSHA) !RSSHA
+    mp_arr%values(54)%obj = mp_float_type(energy%TG) !TG
+    mp_arr%values(55)%obj = mp_float_type(energy%CH) !CH
     mp_arr%values(56)%obj = mp_float_type(energy%FCTR) !FCTR
     mp_arr%values(57)%obj = mp_float_type(energy%PAH) !PAH
     mp_arr%values(58)%obj = mp_float_type(energy%TAUX) !TAUX
@@ -276,9 +276,9 @@ SUBROUTINE energy_serialization (energy, mp_arr)
     mp_arr%values(106)%obj = transfer_values_to_mp(energy%FREVI) !FREVI array  (1:2)
     mp_arr%values(107)%obj = transfer_values_to_mp(energy%FREGI) !FREGI array  (1:2)
     mp_arr%values(108)%obj = transfer_values_to_mp(energy%STC) !STC array
-    mp_arr%values(109)%obj = transfer_values_to_mp(energy%HCPCT ) !HCPCT array  (-levels%NSNOW+1:levels%NSOIL)
-    mp_arr%values(110)%obj = transfer_values_to_mp(energy%DF ) !DF array  (-levels%NSNOW+1:levels%NSOIL)
-    mp_arr%values(111)%obj = transfer_values_to_mp(energy%FACT ) !FACT array  (-levels%NSNOW+1:levels%NSOIL)
+    mp_arr%values(109)%obj = transfer_values_to_mp(energy%HCPCT) !HCPCT array  (-levels%NSNOW+1:levels%NSOIL)
+    mp_arr%values(110)%obj = transfer_values_to_mp(energy%DF) !DF array  (-levels%NSNOW+1:levels%NSOIL)
+    mp_arr%values(111)%obj = transfer_values_to_mp(energy%FACT) !FACT array  (-levels%NSNOW+1:levels%NSOIL)
     mp_arr%values(112)%obj = transfer_values_to_mp(energy%ALBD)  !ALBD array  (1:parameters%NBAND)
     mp_arr%values(113)%obj = transfer_values_to_mp(energy%ALBI) !ALBI array  (1:parameters%NBAND)
     mp_arr%values(114)%obj = transfer_values_to_mp(energy%ALBGRD) !ALBGRD array  (1:parameters%NBAND)
@@ -802,7 +802,7 @@ SUBROUTINE parameters_serialization (parameters, mp_arr)
     mp_arr%values(2)%obj = mp_float_type(parameters%LAI) !LAI
     mp_arr%values(3)%obj = mp_float_type(parameters%ESAI) !ESAI
     mp_arr%values(4)%obj = mp_float_type(parameters%ELAI) !ELAI
-    mp_arr%values(4)%obj = mp_float_type(parameters%FVEG) !FVEG
+    mp_arr%values(5)%obj = mp_float_type(parameters%FVEG) !FVEG
 
 END SUBROUTINE parameters_serialization
 
@@ -832,11 +832,16 @@ END SUBROUTINE parameters_deserialization
 
 FUNCTION transfer_values_to_mp (src) RESULT (dest)
 
-real, allocatable, dimension(:), intent(in) :: src
-class(mp_arr_type), allocatable :: dest
-integer(kind=int64) :: index
+    real, dimension(:), intent(in) :: src
+    type(mp_arr_type) :: dest
+    integer :: lb, ub, index, arr_size
 
-    do index=LBOUND(src,1), UBOUND(src,1)
+    lb = LBOUND(src,1)
+    ub = UBOUND(src,1)
+    arr_size = size(src)
+    dest = mp_arr_type(arr_size)
+    
+    do index = lb, ub
         dest%values(index)%obj = mp_float_type(src(index))
     end do
 
@@ -844,11 +849,16 @@ END FUNCTION transfer_values_to_mp
 
 FUNCTION transfer_values_to_mp_int (src) RESULT (dest)
 
-integer, allocatable, dimension(:), intent(in) :: src
-class(mp_arr_type), allocatable :: dest
-integer(kind=int64) :: index
+    integer, dimension(:), intent(in) :: src
+    type(mp_arr_type) :: dest
+    integer :: lb, ub, index, arr_size
 
-    do index=LBOUND(src,1), UBOUND(src,1)
+    lb = LBOUND(src,1)
+    ub = UBOUND(src,1)
+    arr_size = size(src)
+    dest = mp_arr_type(arr_size)
+
+    do index = lb, ub
         dest%values(index)%obj = mp_int_type(src(index))
     end do
 
@@ -856,13 +866,18 @@ END FUNCTION transfer_values_to_mp_int
 
 FUNCTION transfer_values_from_mp (src) RESULT (dest)
 
-class(mp_arr_type), allocatable, intent(in) :: src
-real, allocatable, dimension(:) :: dest
-real(kind=real64) :: deserialized_val
-integer(kind=int64) :: index
-logical :: status
+    class(mp_arr_type), intent(in) :: src
+    real, allocatable, dimension(:) :: dest
+    real(kind=real64) :: deserialized_val
+    integer :: index, lb, ub
+    logical :: status
     
-    do index=1, src%numelements()
+    lb = lbound(src%values, 1)
+    ub = ubound(src%values, 1)
+
+    allocate(dest(lb:ub))
+    
+    do index = lb, ub
         call get_real(src%values(index)%obj, deserialized_val, status)
         dest(index) = deserialized_val
     end do
@@ -871,13 +886,18 @@ END FUNCTION transfer_values_from_mp
 
 FUNCTION transfer_values_from_mp_int (src) RESULT (dest)
 
-class(mp_arr_type), allocatable, intent(in) :: src
-integer, allocatable, dimension(:) :: dest
-integer(kind=int64) :: deserialized_int_val
-integer(kind=int64) :: index
-logical :: status
+    class(mp_arr_type), intent(in) :: src
+    integer, allocatable, dimension(:) :: dest
+    integer(kind=int64) :: deserialized_int_val
+    integer :: index, lb, ub
+    logical :: status
     
-    do index=1, src%numelements()
+    lb = lbound(src%values, 1)
+    ub = ubound(src%values, 1)
+
+    allocate(dest(lb:ub))
+
+    do index = lb, ub
         call get_int(src%values(index)%obj, deserialized_int_val, status)
         dest(index) = deserialized_int_val
     end do


### PR DESCRIPTION
BMI save state implementation currently includes saving and loading the current time of the BMI. This is needed for properly loading state during checkpointing, but that would cause hindcasting loading of states to continually increase, and some BMIs might start looking for data in indexes out of range from the configuration files. An additional SetValue message of "reset_time" is needed to allow the NOAH OWP BMI to reset its current time to 0 as well as update any other values that create a BMI state equivalent to starting at 0.

Additional changes made to facilitate messaging between NGEN and the Fortran BMI.

Changes:
 - bmi_noahowp.f90: Added a new case for `reset_time` in `noahowp_set_int` function that calls another subroutine to reset time variables.
 - RunModule.f90: Added a new function `reset_model_time` that resets time variables.
 - `serialization_size` is a valid input for allowing the `get_var_nbytes` to reflect an incoming size for serialized data. This works around the limitation of passing arbitrarily sized serialization data to the Fortran BMI to read.